### PR TITLE
Improve the virtualenv.cmake script for Ninja

### DIFF
--- a/virtualenv.cmake
+++ b/virtualenv.cmake
@@ -136,6 +136,7 @@ function(add_venv_target)
         DEPENDS
             ${PARSED_NAME}_VENV
             "${PARSED_DEPENDS}"
+        USES_TERMINAL
     )
 
 endfunction()


### PR DESCRIPTION
Add the USES_TERMINAL option to [add_custom_command](https://cmake.org/cmake/help/latest/command/add_custom_target.html#add-custom-target) to allow Ninja to write the logs in the console as they come in, rather than all at once. This is especially useful when running pytest in a virtualenv.
This change has been tested on Windows and Linux.