### PR TITLE
Support virtualenv target OUTPUT argument

### DIFF
--- a/python-package.cmake
+++ b/python-package.cmake
@@ -185,7 +185,6 @@ function(add_python_package)
                         ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_NAME}
             DEPENDS
                 ${PARSED_LIBRARIES}
-                ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_NAME}
         )
 
         # Add a custom target to generate the wheel inside a virtual environment


### PR DESCRIPTION
Currently OUTPUT argument is used when creating python package using `add_python_package`, but this was not supported by `add_venv_target`.
Adding this support allows to avoid rebuilding python packages if they did not change.